### PR TITLE
Reset $PWD after traversal

### DIFF
--- a/npm-start.sh
+++ b/npm-start.sh
@@ -4,14 +4,16 @@ update_path () {
   local prev=""
   local rel="node_modules/.bin"
   local result=""
-
+  local curr=$PWD
+  
   while [ "$PWD" != "$prev" ]; do
     prev="$PWD"
     [ -d "node_modules/.bin" ] && result="$result$rel:"
     rel="../$rel"
     cd ..
   done
-
+  cd $curr
+  
   export PATH="$result$PATH"
 }
 


### PR DESCRIPTION
`update_path` was mutating $PWD and resulted in `Error: No start script specified.` because $PWD ends up being /.
